### PR TITLE
Setup Next.js skeleton site

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,23 @@
-Placeholder
+# Personal Site
+
+This is a simple Next.js project inspired by the nostalgic look of Geocities while using modern tooling.
+
+## Pages
+- Home
+- About
+- Photography
+- Projects
+- Blog
+- Contact
+- Admin dashboard (for managing posts and photos)
+
+The admin dashboard is intended to integrate with an S3 bucket for photo storage and provide a WYSIWYG markdown editor for blog posts. Photo uploads should read EXIF data using utility functions from `@/utility/exif`. Hidden share links can be generated for private photos.
+
+To get started:
+
+```bash
+npm install
+npm run dev
+```
+
+You'll need to configure AWS credentials and any additional setup for the admin tools.

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "personal-site",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "next": "14.2.3",
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
+    "react-quill": "2.0.0"
+  },
+  "devDependencies": {
+    "@types/react": "18.2.7",
+    "@types/node": "20.11.30",
+    "eslint": "8.57.0",
+    "eslint-config-next": "14.2.3",
+    "typescript": "5.4.5"
+  }
+}

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -1,0 +1,8 @@
+export default function Page() {
+  return (
+    <div>
+      <h1>About</h1>
+      <p>Coming soon!</p>
+    </div>
+  );
+}

--- a/src/app/admin/Editor.tsx
+++ b/src/app/admin/Editor.tsx
@@ -1,0 +1,11 @@
+'use client';
+import dynamic from 'next/dynamic';
+import 'react-quill/dist/quill.snow.css';
+
+const ReactQuill = dynamic(() => import('react-quill'), { ssr: false });
+
+export default function Editor() {
+  return (
+    <ReactQuill theme="snow" />
+  );
+}

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -1,0 +1,13 @@
+'use client';
+import dynamic from 'next/dynamic';
+import Editor from './Editor';
+
+export default function Admin() {
+  return (
+    <div>
+      <h1>Admin Dashboard</h1>
+      <p>Manage your blog posts and photos here.</p>
+      <Editor />
+    </div>
+  );
+}

--- a/src/app/api/photos/route.ts
+++ b/src/app/api/photos/route.ts
@@ -1,0 +1,7 @@
+// Placeholder API route for photo management
+import { NextRequest, NextResponse } from 'next/server';
+
+export async function POST(request: NextRequest) {
+  // TODO: upload to S3 and return info
+  return NextResponse.json({ success: true });
+}

--- a/src/app/api/share/route.ts
+++ b/src/app/api/share/route.ts
@@ -1,0 +1,7 @@
+// Placeholder API route for generating share links
+import { NextRequest, NextResponse } from 'next/server';
+
+export async function POST(request: NextRequest) {
+  // TODO: generate a signed URL or token
+  return NextResponse.json({ url: '/placeholder-private-link' });
+}

--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -1,0 +1,8 @@
+export default function Page() {
+  return (
+    <div>
+      <h1>Blog</h1>
+      <p>Coming soon!</p>
+    </div>
+  );
+}

--- a/src/app/components/Nav.tsx
+++ b/src/app/components/Nav.tsx
@@ -1,0 +1,16 @@
+import Link from 'next/link';
+
+export default function Nav() {
+  return (
+    <nav style={{ background: 'hotpink', padding: '1rem' }}>
+      <ul style={{ display: 'flex', gap: '1rem', listStyle: 'none' }}>
+        <li><Link href="/">Home</Link></li>
+        <li><Link href="/about">About</Link></li>
+        <li><Link href="/photography">Photography</Link></li>
+        <li><Link href="/projects">Projects</Link></li>
+        <li><Link href="/blog">Blog</Link></li>
+        <li><Link href="/contact">Contact</Link></li>
+      </ul>
+    </nav>
+  );
+}

--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -1,0 +1,8 @@
+export default function Page() {
+  return (
+    <div>
+      <h1>Contact</h1>
+      <p>Email: <a href="mailto:me@mattdav.is">me@mattdav.is</a></p>
+    </div>
+  );
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,0 +1,9 @@
+body {
+  margin: 0;
+  padding: 0;
+}
+
+h1 {
+  color: purple;
+  text-shadow: 2px 2px yellow;
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,0 +1,19 @@
+import './globals.css';
+import Nav from './components/Nav';
+import { ReactNode } from 'react';
+
+export const metadata = {
+  title: 'Matt Davis',
+  description: 'A site with big Geocities energy',
+};
+
+export default function RootLayout({ children }: { children: ReactNode }) {
+  return (
+    <html lang="en">
+      <body style={{ fontFamily: 'Comic Sans MS, cursive, sans-serif', background: '#f0f0f0' }}>
+        <Nav />
+        <main style={{ padding: '1rem' }}>{children}</main>
+      </body>
+    </html>
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,0 +1,8 @@
+export default function Home() {
+  return (
+    <div>
+      <h1>Welcome to Matt's Site!</h1>
+      <p>This site brings back the vibes of old-school Geocities, built with modern tech.</p>
+    </div>
+  );
+}

--- a/src/app/photography/page.tsx
+++ b/src/app/photography/page.tsx
@@ -1,0 +1,8 @@
+export default function Page() {
+  return (
+    <div>
+      <h1>Photography</h1>
+      <p>Coming soon!</p>
+    </div>
+  );
+}

--- a/src/app/projects/page.tsx
+++ b/src/app/projects/page.tsx
@@ -1,0 +1,8 @@
+export default function Page() {
+  return (
+    <div>
+      <h1>Projects</h1>
+      <p>Coming soon!</p>
+    </div>
+  );
+}

--- a/src/utility/exif.ts
+++ b/src/utility/exif.ts
@@ -1,0 +1,6 @@
+// Placeholder for EXIF extraction utilities
+// In a real setup you might use exifr or a similar library
+export async function readExif(file: File) {
+  // TODO: parse EXIF data from file
+  return {};
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": false,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  },
+  "include": ["next-env.d.ts", "src/**/*.ts", "src/**/*.tsx"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- initialize basic Next.js app layout with TypeScript
- add placeholder pages (Home, About, Photography, Projects, Blog, Contact)
- add Admin dashboard with React-Quill WYSIWYG editor
- include placeholder API routes and EXIF utility
- update README with instructions

## Testing
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68432406e3a88322a339c9b65f3118cd